### PR TITLE
Issue: errors with `README.md` and `python==3.12`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <br>
 </div>
 
+
 ## Help
 See [documentation](https://pydantic-argparse.supimdos.com) for help.
 


### PR DESCRIPTION
### 1. It's impossible to create issue in this repository

<img width="1051" height="297" alt="image" src="https://github.com/user-attachments/assets/b2d0ebfb-2d92-494b-97f1-3892e0cfa420" />


### 2. Example from `README.md` does not work.
**Current code:**
```python
def main() -> None:
    # Create Parser and Parse Args
    parser = ArgumentParser(
        model=Arguments,
        prog="Example Program",
        description="Example Description",
        version="0.0.1",
        epilog="Example Epilog",
    )
    args = parser.parse_typed_args()
```

**Traceback:**
```python
    parser = ArgumentParser(
             ^^^^^^^^^^^^^^^
TypeError: ArgumentParser.__init__() got an unexpected keyword argument 'model'
```

### Python 3.12 error

**Traceback**
```
D:\Code\project\.venv\Scripts\python.exe D:\Code\project\check_pydantic_args.py
Traceback (most recent call last):
  File "D:\Code\project\check_pydantic_args.py", line 31, in <module>
    main()
  File "D:\Code\project\check_pydantic_args.py", line 17, in main
    parser = ArgumentParser(
             ^^^^^^^^^^^^^^^
  File "D:\Code\project\.venv\Lib\site-packages\argparse_dantic\_argparse\parser.py", line 144, in __init__
    self._add_help_flag()
  File "D:\Code\project\.venv\Lib\site-packages\argparse_dantic\_argparse\parser.py", line 1047, in _add_help_flag
    self._help_group.add_argument(
  File "D:\Code\project\.venv\Lib\site-packages\argparse_dantic\_argparse\container.py", line 127, in add_argument
    action = action_class(**kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "D:\Code\project\.venv\Lib\site-packages\argparse_dantic\_argparse\actions.py", line 494, in __init__
    super(_HelpAction, self).__init__(
  File "D:\Code\project\.venv\Lib\site-packages\argparse_dantic\_argparse\actions.py", line 53, in __init__
    super().__init__(
TypeError: Action.__init__() got an unexpected keyword argument 'deprecated'

Process finished with exit code 1

```